### PR TITLE
Use square brackets to access string offsets

### DIFF
--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -55,7 +55,7 @@ namespace {
 
             $hash = sha1($hostname . $username . $flags);
             /* persistent connections start with p: */
-            if ($hostname{1} !== ':' && isset(\Dshafik\MySQL::$connections[$hash])) {
+            if ($hostname[1] !== ':' && isset(\Dshafik\MySQL::$connections[$hash])) {
                 \Dshafik\MySQL::$last_connection = \Dshafik\MySQL::$connections[$hash]['conn'];
                 \Dshafik\MySQL::$connections[$hash]['refcount'] += 1;
                 return \Dshafik\MySQL::$connections[$hash]['conn'];
@@ -729,7 +729,7 @@ namespace Dshafik {
         {
             $escapedString = '';
             for ($i = 0, $max = strlen($unescapedString); $i < $max; $i++) {
-                $escapedString .= self::escapeChar($unescapedString{$i});
+                $escapedString .= self::escapeChar($unescapedString[$i]);
             }
 
             return $escapedString;


### PR DESCRIPTION
Curly brace syntax for accessing array elements and string offsets is deprecated since PHP 7.4.

See: https://wiki.php.net/rfc/deprecate_curly_braces_array_access